### PR TITLE
feat: add claude support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build clean run version
 
 BINARY_NAME=propr
-VERSION=2.4.2
+VERSION=2.5.0
 BUILD_DIR=bin
 
 GOFLAGS=CGO_ENABLED=0

--- a/anthropic.go
+++ b/anthropic.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+var _ MessageClient = (*Anthropic)(nil)
+
+type ClaudeMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ClaudeMessagesRequest struct {
+	Model     string          `json:"model"`
+	MaxTokens int             `json:"max_tokens"`
+	System    string          `json:"system"`
+	Messages  []ClaudeMessage `json:"messages"`
+}
+
+type ClaudeMessagesResponseContent struct {
+	Text string `json:"text"`
+	Type string `json:"type"`
+}
+
+type ClaudeMessagesResponseUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+type ClaudeMessagesResponse struct {
+	ID      string                          `json:"id"`
+	Role    string                          `json:"role"`
+	Model   string                          `json:"model"`
+	Content []ClaudeMessagesResponseContent `json:"content"`
+	Usage   ClaudeMessagesResponseUsage     `json:"usage"`
+}
+
+type Anthropic struct {
+	apiKey string
+	model  string
+}
+
+func NewAnthropic(apiKey, model string) *Anthropic {
+	return &Anthropic{
+		apiKey,
+		model,
+	}
+}
+
+func (a *Anthropic) CreateMessage(ctx context.Context, system string, prompt string) (string, error) {
+	body, err := json.Marshal(map[string]interface{}{
+		"model":      a.model,
+		"max_tokens": 4096,
+		"system":     system,
+		"messages": []ClaudeMessage{
+			{
+				Role:    MessageRoleUser,
+				Content: prompt,
+			},
+		},
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("error marshaling JSON payload: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewBuffer(body))
+	if err != nil {
+		return "", fmt.Errorf("error creating request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", a.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error sending request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var data ClaudeMessagesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", fmt.Errorf("error decoding response: %v", err)
+	}
+
+	return data.Content[0].Text, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/sashabaranov/go-openai v1.24.0 // indirect
+	github.com/sashabaranov/go-openai v1.31.0 // indirect
 	github.com/segersniels/config v0.0.0-20240503115636-403023c44d9f // indirect
 	github.com/urfave/cli/v2 v2.27.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/sashabaranov/go-openai v1.22.0 h1:bjYkELQCbOBMW9B7zi/KA5L4syPfn/3qRvU
 github.com/sashabaranov/go-openai v1.22.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/sashabaranov/go-openai v1.24.0 h1:4H4Pg8Bl2RH/YSnU8DYumZbuHnnkfioor/dtNlB20D4=
 github.com/sashabaranov/go-openai v1.24.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/sashabaranov/go-openai v1.31.0 h1:rGe77x7zUeCjtS2IS7NCY6Tp4bQviXNMhkQM6hz/UC4=
+github.com/sashabaranov/go-openai v1.31.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/segersniels/config v0.0.0-20240503115636-403023c44d9f h1:Hryp2S1kBLyBv78hV2/YQPzwz5xYy0VsixFBqYNXfHc=
 github.com/segersniels/config v0.0.0-20240503115636-403023c44d9f/go.mod h1:ZtYAvjzw4Y8B72nIjqWUnwYKeveEfiNbUilY/ts5MYE=
 github.com/urfave/cli/v2 v2.27.1 h1:8xSQ6szndafKVRmfyeUMxkNUJQMjL1F2zmsZ+qHpfho=

--- a/main.go
+++ b/main.go
@@ -44,12 +44,8 @@ type Config struct {
 }
 
 var CONFIG = config.NewConfig("propr", Config{
-	Model: openai.GPT4o,
-	Prompt: `You will be asked to write a concise GitHub PR description based on a provided git diff.
-Analyze the code changes and provide a concise explanation of the changes, their context and why they were made.
-Don't reference file names or directories directly, instead give a general explanation of the changes made.
-Do not treat imports and requires as changes or new features. If the provided message is not a diff respond with an appropriate message.
-Don't surround your description in backticks but still write GitHub supported markdown.`,
+	Model:       openai.GPT4o,
+	Prompt:      SYSTEM_MESSAGE,
 	Template:    "# Description",
 	PrettyPrint: true,
 })

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,17 +18,29 @@ import (
 var AppVersion string
 var AppName string
 
-type AssistantConfig struct {
-	Enabled bool   `json:"enabled"`
-	Id      string `json:"id"`
+const (
+	GPT4o             = "gpt-4o"
+	GPT4oMini         = "gpt-4o-mini"
+	GPT4Turbo         = "gpt-4-turbo"
+	GPT3Dot5Turbo     = "gpt-3.5-turbo"
+	Claude3Dot5Sonnet = "claude-3-5-sonnet-20240620"
+)
+
+const (
+	MessageRoleSystem    = "system"
+	MessageRoleUser      = "user"
+	MessageRoleAssistant = "assistant"
+)
+
+type MessageClient interface {
+	CreateMessage(ctx context.Context, system string, prompt string) (string, error)
 }
 
 type Config struct {
-	Model       string          `json:"model"`
-	Prompt      string          `json:"prompt"`
-	Template    string          `json:"template"`
-	PrettyPrint bool            `json:"pretty_print"`
-	Assistant   AssistantConfig `json:"assistant"`
+	Model       string `json:"model"`
+	Prompt      string `json:"prompt"`
+	Template    string `json:"template"`
+	PrettyPrint bool   `json:"pretty_print"`
 }
 
 var CONFIG = config.NewConfig("propr", Config{
@@ -39,10 +52,6 @@ Do not treat imports and requires as changes or new features. If the provided me
 Don't surround your description in backticks but still write GitHub supported markdown.`,
 	Template:    "# Description",
 	PrettyPrint: true,
-	Assistant: AssistantConfig{
-		Enabled: false,
-		Id:      "",
-	},
 })
 
 func printMarkdown(content string, pretty bool) error {
@@ -168,22 +177,12 @@ func main() {
 						Name:  "init",
 						Usage: "Initializes propr with a base configuration",
 						Action: func(ctx *cli.Context) error {
-							models := huh.NewOptions(openai.GPT4o, openai.GPT4Turbo, openai.GPT3Dot5Turbo)
+							models := huh.NewOptions(GPT4oMini, GPT4o, GPT4Turbo, GPT3Dot5Turbo, Claude3Dot5Sonnet)
 							form := huh.NewForm(
-								huh.NewGroup(
-									huh.NewConfirm().Title("Assistant").Description("Do you want to use an OpenAI assistant to control your prompt?").Value(&CONFIG.Data.Assistant.Enabled),
-								),
-								huh.NewGroup(
-									huh.NewInput().Title("Assistant").Description("Provide the assistant's id").Value(&CONFIG.Data.Assistant.Id),
-								).WithHideFunc(func() bool {
-									return !CONFIG.Data.Assistant.Enabled
-								}),
 								huh.NewGroup(
 									huh.NewSelect[string]().Title("Model").Description("Configure the default model").Options(models...).Value(&CONFIG.Data.Model),
 									huh.NewText().Title("Prompt").Description("Configure the default prompt").CharLimit(99999).Value(&CONFIG.Data.Prompt),
-								).WithHideFunc(func() bool {
-									return CONFIG.Data.Assistant.Enabled
-								}),
+								),
 								huh.NewGroup(
 									huh.NewText().Title("Template").Description("Configure the default template").Value(&CONFIG.Data.Template),
 								),

--- a/openai.go
+++ b/openai.go
@@ -2,118 +2,38 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"strings"
-	"sync"
 
-	"github.com/charmbracelet/log"
 	openai "github.com/sashabaranov/go-openai"
 )
 
-var FILES_TO_IGNORE = []string{
-	"package-lock.json",
-	"yarn.lock",
-	"npm-debug.log",
-	"yarn-debug.log",
-	"yarn-error.log",
-	".pnpm-debug.log",
-	"Cargo.lock",
-	"Gemfile.lock",
-	"mix.lock",
-	"Pipfile.lock",
-	"composer.lock",
-	"go.sum",
-}
-
-func splitDiffIntoChunks(diff string) []string {
-	split := strings.Split(diff, "diff --git")[1:]
-	for i, chunk := range split {
-		split[i] = strings.TrimSpace(chunk)
-	}
-
-	return split
-}
-
-func removeLockFiles(chunks []string) []string {
-	var wg sync.WaitGroup
-
-	filtered := make(chan string)
-
-	for _, chunk := range chunks {
-		wg.Add(1)
-
-		go func(chunk string) {
-			defer wg.Done()
-			shouldIgnore := false
-			header := strings.Split(chunk, "\n")[0]
-
-			// Check if the first line contains any of the files to ignore
-			for _, file := range FILES_TO_IGNORE {
-				if strings.Contains(header, file) {
-					log.Debug("Ignoring", "file", file)
-					shouldIgnore = true
-				}
-			}
-
-			if !shouldIgnore {
-				log.Debug("Adding", "header", header)
-				filtered <- chunk
-			}
-		}(chunk)
-	}
-
-	go func() {
-		wg.Wait()
-		close(filtered)
-	}()
-
-	var result []string
-	for chunk := range filtered {
-		result = append(result, chunk)
-	}
-
-	return result
-}
-
-// Split the diff in chunks and remove any lock files to save on tokens
-func prepareDiff(diff string) string {
-	chunks := splitDiffIntoChunks(diff)
-
-	return strings.Join(removeLockFiles(chunks), "\n")
-}
-
-func generateSystemMessageForDiff(systemMessage string, template string) string {
-	return fmt.Sprintf("%s\n\nFollow this exact template to write your description:\n\n```\n%s\n```", systemMessage, template)
-}
-
-func generateUserMessage(diff string, template string) string {
-	return fmt.Sprintf("Use the following template to write your description, don't deviate from the template:\n\n```\n%s\n```\n\nThe diff:\n\n```\n%s\n```", template, prepareDiff(diff))
-}
+var _ MessageClient = (*OpenAI)(nil)
 
 type OpenAI struct {
-	ApiKey string
+	apiKey string
+	model  string
 }
 
-func NewOpenAI(apiKey string) *OpenAI {
+func NewOpenAI(apiKey, model string) *OpenAI {
 	return &OpenAI{
-		ApiKey: apiKey,
+		apiKey,
+		model,
 	}
 }
 
-func (o *OpenAI) GetChatCompletion(diff string) (string, error) {
-	client := openai.NewClient(o.ApiKey)
+func (o *OpenAI) CreateMessage(ctx context.Context, system string, prompt string) (string, error) {
+	client := openai.NewClient(o.apiKey)
 	resp, err := client.CreateChatCompletion(
-		context.Background(),
+		ctx,
 		openai.ChatCompletionRequest{
-			Model: CONFIG.Data.Model,
+			Model: o.model,
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role:    openai.ChatMessageRoleSystem,
-					Content: generateSystemMessageForDiff(CONFIG.Data.Prompt, CONFIG.Data.Template),
+					Content: system,
 				},
 				{
 					Role:    openai.ChatMessageRoleUser,
-					Content: prepareDiff(diff),
+					Content: prompt,
 				},
 			},
 		},
@@ -122,66 +42,6 @@ func (o *OpenAI) GetChatCompletion(diff string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	log.Debug("Run status", "usage", resp.Usage)
 
 	return resp.Choices[0].Message.Content, nil
-}
-
-func (o *OpenAI) GetAssistantCompletion(diff string) (string, error) {
-	config := openai.DefaultConfig(o.ApiKey)
-	config.AssistantVersion = "v2" // `gpt-4o` requires the v2 assistant API
-	client := openai.NewClientWithConfig(config)
-
-	ctx := context.Background()
-	resp, err := client.CreateThreadAndRun(
-		ctx,
-		openai.CreateThreadAndRunRequest{
-			RunRequest: openai.RunRequest{
-				AssistantID: CONFIG.Data.Assistant.Id,
-			},
-			Thread: openai.ThreadRequest{
-				Messages: []openai.ThreadMessage{
-					{
-						Role:    openai.ChatMessageRoleUser,
-						Content: generateUserMessage(diff, CONFIG.Data.Template),
-					},
-				},
-			},
-		},
-	)
-
-	if err != nil {
-		return "", err
-	}
-
-	for {
-		run, err := client.RetrieveRun(ctx, resp.ThreadID, resp.ID)
-		if err != nil {
-			return "", err
-		}
-
-		log.Debug("Run status", "status", run.Status)
-
-		if run.Status == openai.RunStatusFailed || run.Status == openai.RunStatusCancelled || run.Status == openai.RunStatusExpired {
-			return "", fmt.Errorf("run failed: %v", run.LastError)
-		}
-
-		if run.Status == openai.RunStatusCompleted {
-			amountOfMessages := 1
-			messages, err := client.ListMessage(ctx, run.ThreadID, &amountOfMessages, nil, nil, nil)
-
-			if err != nil {
-				return "", err
-			}
-
-			if len(messages.Messages) == 0 {
-				return "", fmt.Errorf("no messages found")
-			}
-
-			log.Debug("Run status", "usage", run.Usage)
-
-			return messages.Messages[0].Content[0].Text.Value, nil
-		}
-	}
 }

--- a/prompt.go
+++ b/prompt.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/charmbracelet/log"
+)
+
+var FILES_TO_IGNORE = []string{
+	"package-lock.json",
+	"yarn.lock",
+	"npm-debug.log",
+	"yarn-debug.log",
+	"yarn-error.log",
+	".pnpm-debug.log",
+	"Cargo.lock",
+	"Gemfile.lock",
+	"mix.lock",
+	"Pipfile.lock",
+	"composer.lock",
+	"go.sum",
+}
+
+func splitDiffIntoChunks(diff string) []string {
+	split := strings.Split(diff, "diff --git")[1:]
+	for i, chunk := range split {
+		split[i] = strings.TrimSpace(chunk)
+	}
+
+	return split
+}
+
+func removeLockFiles(chunks []string) []string {
+	var wg sync.WaitGroup
+
+	filtered := make(chan string)
+
+	for _, chunk := range chunks {
+		wg.Add(1)
+
+		go func(chunk string) {
+			defer wg.Done()
+			shouldIgnore := false
+			header := strings.Split(chunk, "\n")[0]
+
+			// Check if the first line contains any of the files to ignore
+			for _, file := range FILES_TO_IGNORE {
+				if strings.Contains(header, file) {
+					log.Debug("Ignoring", "file", file)
+					shouldIgnore = true
+				}
+			}
+
+			if !shouldIgnore {
+				log.Debug("Adding", "header", header)
+				filtered <- chunk
+			}
+		}(chunk)
+	}
+
+	go func() {
+		wg.Wait()
+		close(filtered)
+	}()
+
+	var result []string
+	for chunk := range filtered {
+		result = append(result, chunk)
+	}
+
+	return result
+}
+
+// Split the diff in chunks and remove any lock files to save on tokens
+func prepareDiff(diff string) string {
+	chunks := splitDiffIntoChunks(diff)
+
+	return strings.Join(removeLockFiles(chunks), "\n")
+}
+
+func generateSystemMessageForDiff(systemMessage string, template string) string {
+	return fmt.Sprintf("%s\n\nFollow this exact template to write your description:\n\n```\n%s\n```", systemMessage, template)
+}
+
+func generateUserMessage(diff string, template string) string {
+	return fmt.Sprintf("Use the following template to write your description, don't deviate from the template:\n\n```\n%s\n```\n\nThe diff:\n\n```\n%s\n```", template, prepareDiff(diff))
+}

--- a/prompt.go
+++ b/prompt.go
@@ -83,7 +83,3 @@ func prepareDiff(diff string) string {
 func generateSystemMessageForDiff(systemMessage string, template string) string {
 	return fmt.Sprintf("%s\n\nFollow this exact template to write your description:\n\n```\n%s\n```", systemMessage, template)
 }
-
-func generateUserMessage(diff string, template string) string {
-	return fmt.Sprintf("Use the following template to write your description, don't deviate from the template:\n\n```\n%s\n```\n\nThe diff:\n\n```\n%s\n```", template, prepareDiff(diff))
-}

--- a/prompt.go
+++ b/prompt.go
@@ -8,6 +8,11 @@ import (
 	"github.com/charmbracelet/log"
 )
 
+const SYSTEM_MESSAGE = `You will be asked to write a concise GitHub PR description based on a provided git diff.
+Analyze the code changes and provide a concise explanation of the changes, their context and why they were made.
+If the provided message is not a diff respond with an appropriate message.
+Don't surround your description in backticks but still write GitHub supported markdown.`
+
 var FILES_TO_IGNORE = []string{
 	"package-lock.json",
 	"yarn.lock",


### PR DESCRIPTION
### Added
- New `anthropic.go` file implementing an Anthropic message client
- New `prompt.go` file with helper functions for preparing diffs and generating system messages

### Changed
- Updated `propr.go` to support multiple message clients (OpenAI and Anthropic)
- Modified `main.go` to include new model options and remove assistant-related configuration
- Updated `openai.go` to implement the `MessageClient` interface
- Bumped version to 2.5.0 in `Makefile`

### Fixed
- Improved error handling and added context with timeout for API requests

### Removed
- Removed assistant-related functionality and configuration options

The changes introduce support for multiple AI providers, specifically adding Anthropic's Claude model alongside existing OpenAI models. The code has been refactored to use a common `MessageClient` interface, allowing for easier integration of different AI services. Configuration options have been simplified, removing assistant-related settings and adding new model choices. Error handling and request timeouts have also been improved for better reliability.